### PR TITLE
Disconnect all signals

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -12,7 +12,7 @@ const Me = ExtensionUtils.getCurrentExtension();
 
 //"User-defined" constants. If you've stumbled upon this extension, these values are the most likely you'd like to change.
 let LEFT_PADDING, MAX_STRING_LENGTH, REFRESH_RATE, FRIENDLY_GREETING, ARTIST_FIRST,  EXTENSION_PLACE, EXTENSION_INDEX, gschema, lastExtensionPlace, lastExtensionIndex;
-var settings;
+var settings, onLeftPaddingChanged, onExtensionPlaceChanged, onExtensionIndexChanged;
 let _httpSession;
 let spMenu;
 
@@ -33,7 +33,7 @@ const SpotifyLabel = new Lang.Class({
 		});
 
 		// Listen for update of padding in settings
-		this.onLeftPaddingChanged = this.settings.connect(
+		onLeftPaddingChanged = this.settings.connect(
 			'changed::left-padding',
 			this._leftPaddingChanged.bind(this)
 		);
@@ -127,12 +127,12 @@ function enable() {
 	this.lastExtensionPlace = settings.get_string('extension-place');
 	this.lastExtensionIndex = settings.get_int('extension-index');
 	
-	this.onExtensionPlaceChanged = this.settings.connect(
+	onExtensionPlaceChanged = this.settings.connect(
 		'changed::extension-place',
 		this.onExtensionLocationChanged.bind(this)
 	);
 
-	this.onExtensionIndexChanged = this.settings.connect(
+	onExtensionIndexChanged = this.settings.connect(
 		'changed::extension-index',
 		this.onExtensionLocationChanged.bind(this)
 	);
@@ -142,6 +142,10 @@ function enable() {
 }
 
 function disable() {
+	this.settings.disconnect(onLeftPaddingChanged);
+	this.settings.disconnect(onExtensionPlaceChanged);
+	this.settings.disconnect(onExtensionIndexChanged);
+
 	spMenu.stop();
 	spMenu.destroy();
 }

--- a/prefs.js
+++ b/prefs.js
@@ -143,7 +143,7 @@ function buildPrefsWidget() {
     
     /* extension-index */
     let extensionIndexLabel = new Gtk.Label({
-        label: 'Extension Index:',
+        label: 'Extension index:',
         halign: Gtk.Align.START,
         visible: true
     });


### PR DESCRIPTION
The various connections are now stored and disconnected afterwards. I hope this is the right way, but since every time I re-enable the extension each of these connections has a different id it seems good to me.

Edit: Should also fix #6 after successful review.