### PR TITLE
Fix spelling mistake in options/config menu (#17)

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -58,7 +58,7 @@ function buildPrefsWidget() {
 
     /* max-string-length */
     let maxStringLengthLabel = new Gtk.Label({
-        label: 'Max string length (Each artist and titel):',
+        label: 'Max string length (Each artist and title):',
         halign: Gtk.Align.START,
         visible: true
     });


### PR DESCRIPTION
This fixes the spelling mistake [here](https://github.com/mheine/gnome-shell-spotify-label/blob/ab0baec9affa9ece6a7c0835ae38a6bae3795264/prefs.js#L61), detailed in issue #17.