### PR TITLE
Multiple player dev

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -98,7 +98,7 @@ const SpotifyLabel = new Lang.Class({
 			return;
 		}
 		//player = 'vlc'; // testing
-		global.log(`\n\nSpotifyLabel: player: ${player}`);
+		global.log(`\nSpotifyLabel: player: ${player}`);
 
 		let [res, out, err, status] = [];
 		try {
@@ -287,28 +287,41 @@ function toggleWindow() {
 	}
 }
 
-const players = [
-	'amazrok',
-	'vvave',
-	'elisa', // installed
-	'juk',
-	'plasma-media-center',
-	'gwenview', // an image viewer ????????
-	'plasma-browser-integration',
-	'idea-okular', // (presentation)
-	'vlc', // installed
-	'spotify', // installed
-];
+/*
+Javascript Object is implemented using a HashTable (https://stackoverflow.com/a/24196259).
+So to enable faster checking for players, 'players' should be implemented as an Object instead of an Array. Then
+we can just iterate through the current open windows and check if that window is in players. Thus O(n) instead
+of O(n^2) of checking if the window is in the players array. The Object should map the 'window_actor.meta_window.wm_class'
+(i.e. what is given after mapping a windowActor to its name) to the name that is used to identify the path in the dbus-send
+command.
+*/
+const players = {
+	amazrok: 'amazrok',
+	vvave: 'vvave',
+	elisa: 'elisa', // installed, works
+	juk: 'juk',
+	plasma_media_center: 'plasma-media-center', // '_' might be '-'
+	gwenview: 'gwenview', // an image viewer ????????
+	plasma_browser_integration: 'plasma-browser-integration',
+	idea_okular: 'idea-okular', // (presentation) ('_' might be @, or maybe even ':' ?)
+	vlc: 'vlc', // installed, works
+	spotify: 'spotify', // installed, works
+}
 
 function getPlayer() {
-	for (var i = 0; i < players.length; i++) {
-		const player = players[i];
+	// get the names(? - is it the names?) of the current open windows
+	let windowActors = global.get_window_actors();
+	let windowNames = windowActors.map(w => w.get_meta_window().get_wm_class().toLowerCase());
 
-		let [res, out, err, status] = GLib.spawn_command_line_sync(`pgrep -i -x "${player}"`);
+	// debug
+	global.log('\n'+windowNames);
 
-		if (out.length > 0)
-			return player;
+	for (let windowName of windowNames) {
+		if (players[windowName])
+			return players[windowName];
 	}
+
+	global.log('\nSpotifyLabel: no player open!'); //debug
 }
 
 let genres = ["DnB", "Synthwave", "Dubstep", "Pop", "House", "Hardstyle", "Rock", "8-bit", "Classical", "Electro"]

--- a/extension.js
+++ b/extension.js
@@ -1,12 +1,16 @@
-const St = imports.gi.St;
-const Main = imports.ui.main;
+const Clutter = imports.gi.Clutter;
+const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
 const Soup = imports.gi.Soup;
+const St = imports.gi.St;
+
+const Main = imports.ui.main;
+const PanelMenu = imports.ui.panelMenu;
+
+const ByteArray = imports.byteArray;
 const Lang = imports.lang;
 const Mainloop = imports.mainloop;
-const Clutter = imports.gi.Clutter;
-const PanelMenu = imports.ui.panelMenu;
-const GLib = imports.gi.GLib;
-const Gio = imports.gi.Gio;
+
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 
@@ -109,7 +113,7 @@ const SpotifyLabel = new Lang.Class({
 			return;
 		}
 
-		var labelstring = parseSpotifyData(out.toString());
+		var labelstring = parseSpotifyData(ByteArray.toString(out));
 		this._refreshUI(labelstring);
 	},
 

--- a/extension.js
+++ b/extension.js
@@ -97,8 +97,6 @@ const SpotifyLabel = new Lang.Class({
 			this._refreshUI('');
 			return;
 		}
-		//player = 'vlc'; // testing
-		global.log(`\nSpotifyLabel: player: ${player}`);
 
 		let [res, out, err, status] = [];
 		try {
@@ -296,18 +294,16 @@ of O(n^2) of checking if the window is in the players array. The Object should m
 command.
 */
 const players = {
-	amazrok: 'amazrok',
-	vvave: 'vvave',
-	elisa: 'elisa', // installed, works
-	juk: 'juk',		// installed, works
-	plasma_media_center: 'plasma-media-center', // '_' might be '-'
-	gwenview: 'gwenview', // an image viewer ????????
-	plasma_browser_integration: 'plasma-browser-integration',
-	idea_okular: 'idea-okular', // (presentation) ('_' might be @, or maybe even ':' ?)
-	vlc: 'vlc',		// installed, works
-	Spotify: 'spotify', // installed, works
+	amarok: 'amarok',			// not sure if works
+	vvave: 'vvave',				// not sure if works
+	elisa: 'elisa',
+	juk: 'juk',
+	plasma_media_center: 'plasma-media-center', 			  // not sure if works
+	plasma_browser_integration: 'plasma-browser-integration', // not sure if works
+	vlc: 'vlc',
+	Spotify: 'spotify',
 	Clementine: 'clementine',
-	Rhythmbox: 'rhythmbox',	// installed, works
+	Rhythmbox: 'rhythmbox',
 }
 
 function getPlayer() {
@@ -315,15 +311,10 @@ function getPlayer() {
 	let windowActors = global.get_window_actors();
 	let windowNames = windowActors.map(w => w.get_meta_window().get_wm_class());
 
-	// debug
-	global.log('\n'+windowNames);
-
 	for (let windowName of windowNames) {
 		if (players[windowName])
 			return players[windowName];
 	}
-
-	global.log('\nSpotifyLabel: no player open!'); //debug
 }
 
 let genres = ["DnB", "Synthwave", "Dubstep", "Pop", "House", "Hardstyle", "Rock", "8-bit", "Classical", "Electro"]

--- a/extension.js
+++ b/extension.js
@@ -299,19 +299,21 @@ const players = {
 	amazrok: 'amazrok',
 	vvave: 'vvave',
 	elisa: 'elisa', // installed, works
-	juk: 'juk',
+	juk: 'juk',		// installed, works
 	plasma_media_center: 'plasma-media-center', // '_' might be '-'
 	gwenview: 'gwenview', // an image viewer ????????
 	plasma_browser_integration: 'plasma-browser-integration',
 	idea_okular: 'idea-okular', // (presentation) ('_' might be @, or maybe even ':' ?)
-	vlc: 'vlc', // installed, works
-	spotify: 'spotify', // installed, works
+	vlc: 'vlc',		// installed, works
+	Spotify: 'spotify', // installed, works
+	Clementine: 'clementine',
+	Rhythmbox: 'rhythmbox',	// installed, works
 }
 
 function getPlayer() {
 	// get the names(? - is it the names?) of the current open windows
 	let windowActors = global.get_window_actors();
-	let windowNames = windowActors.map(w => w.get_meta_window().get_wm_class().toLowerCase());
+	let windowNames = windowActors.map(w => w.get_meta_window().get_wm_class());
 
 	// debug
 	global.log('\n'+windowNames);


### PR DESCRIPTION
Start of attempt to solve #16 (request to support other players)

- Added checking which player is open ([linear time ;)](https://github.com/mheine/gnome-shell-spotify-label/issues/16#issuecomment-781737066) )
- 'Verified' that VLC & Elisa work - if the media file has defined Title & Artist tags

Also [extension.js:59](https://github.com/mheine/gnome-shell-spotify-label/blob/11e3563168b7cfe5b45e08bae53222945d0dc683/extension.js#L59) there should be `let/var` before `children` as it's previously undefined and was giving JS Warnings in Gnome-SHELL logs.

I still need to check the other players and check which other players support MPRIS, including Clementine & RhythmBox that the issue OP wanted (I mean add it to the `players` object and check it works).