### PR TITLE
Correct remix-hypen pattern

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -228,8 +228,8 @@ function parseSpotifyData(data) {
 	var artistBlock = data.substring(data.indexOf("xesam:artist"));
 	var artist = artistBlock.split("\"")[2]
 
-	//If the delimited '-' is in the title, we assume that it's remix, and encapsulate the end in brackets.
-	if(title.includes("-"))
+	//If the delimited ' - '(with spaces) is in the title, we assume that it's remix, and encapsulate the end in brackets.
+	if(title.includes(" - "))
 		title = title.replace("- ", "(") + ")";
 
 	//If the name of either string is too long, cut off and add '...'


### PR DESCRIPTION
Remix hyphen assumption doesn't work with names and tracks in Hindi, Urdu, Persian. Corrected it.

Example (track info, result):
![image](https://user-images.githubusercontent.com/48156230/212633518-8cbfbe34-88ed-42a8-90d1-717d8659309c.png)
![image](https://user-images.githubusercontent.com/48156230/212633445-3c87caa2-e543-4e46-8b89-c667fe0a16c5.png)


Remixes are not affected.

See #23 