### PR TITLE
Feature: Prevent artist and song names from being cut off mid senten...

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -233,11 +233,15 @@ function parseSpotifyData(data) {
 		title = title.replace("- ", "(") + ")";
 
 	//If the name of either string is too long, cut off and add '...'
-	if (artist.length > this.settings.get_int('max-string-length'))
-		artist = artist.substring(0, this.settings.get_int('max-string-length')) + "...";
+	if (artist.length > this.settings.get_int('max-string-length')){
+		artist = artist.substring(0, this.settings.get_int('max-string-length'));
+		artist = artist.substring(0, artist.lastIndexOf(" ")) + "...";
+	}
 
-	if (title.length > this.settings.get_int('max-string-length'))
-		title = title.substring(0, this.settings.get_int('max-string-length')) + "...";
+	if (title.length > this.settings.get_int('max-string-length')){
+		title = title.substring(0, this.settings.get_int('max-string-length'));
+		title = title.substring(0, title.lastIndexOf(" ")) + "...";
+	}
 
 	if (title.includes("xesam") || artist.includes("xesam"))
 		return "Loading..."


### PR DESCRIPTION
**if a string is too long, it's cut in the last space (if there's any) and '...' is added**
i'm not confident enough in my english to edit the comment as well.

In the case a string HasNoSpaces and exceeds the character limit [lastIndexOf will return -1](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/lastIndexOf)
So, only ```'...'``` will be added to it