### PR TITLE
Changed separator character and replacement behaviour

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -228,9 +228,12 @@ function parseSpotifyData(data) {
 	var artistBlock = data.substring(data.indexOf("xesam:artist"));
 	var artist = artistBlock.split("\"")[2]
 
-	//If the delimited '-' is in the title, we assume that it's remix, and encapsulate the end in brackets.
-	if(title.includes("-"))
-		title = title.replace("- ", "(") + ")";
+	//Replaces every instance of " | "
+	if(title.includes(" | "))
+		title = title.replace(/ \| /g, " / ");
+
+	if(artist.includes(" | "))
+		artist = artist.replace(/ \| /g," / ");
 
 	//If the name of either string is too long, cut off and add '...'
 	if (artist.length > this.settings.get_int('max-string-length'))
@@ -242,10 +245,10 @@ function parseSpotifyData(data) {
 	if (title.includes("xesam") || artist.includes("xesam"))
 		return "Loading..."
 
-	if (this.settings.get_boolean('artist-first')) {
-    	return (artist + " - " + title);
-  	}
-  	return (title + " - " + artist);
+	if (this.settings.get_boolean('artist-first'))
+		return (artist + " | " + title);
+
+	return (title + " | " + artist);
 }
 
 function toggleWindow() {


### PR DESCRIPTION
**Replacement behaviour:**
Replace every instance of the separator character surrounded by spaces within the string, If any.

**Dropped the parenthesis:**
To correctly replace multiple ```-``` or any other character with a pair of parentheses and surround the correct part of the string needs more complicated code that it really needs to be.
At the core it's just preventing the desired character from appearing as a different separator within the string.

**Changed ```-``` as separator because it's too common and it doesn't have a good replacement.**

- ```-``` doesn't have a distinct enough and similar enough character to be replaced with

- Possible candidates like ```―``` are more eye-catching than the separator itself 

**Changed it to ```|``` because it's a uncommon character and easier to replace with ```/```**

- ```/``` it's distinct enough to not be confused with ```|``` , conveys the same meaning, and it's not distracting

- Because it's rarely used, most strings will be left intact

- It doesn't clashes with itself (at least i don't think it does) an output like ```Dust | M|O|O|N``` looks fine

If you want to still use ```-``` as title - artist separator, maybe replacing it with ```/``` would work.

**Perhaps it's a good a idea to make it a settings option?** 